### PR TITLE
additional bucket policy (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acm_certificate_arn | Existing ACM Certificate ARN | string | `` | no |
+| additional_bucket_policy | Additional policies for the bucket. If included in the policies, the variables `$${bucket_name}`, `$${origin_path}` and `$${cloudfront_origin_access_identity_iam_arn}` will be substituted. It is also possible to override the default policy statements by providing statements with `S3GetObjectForCloudFront` and `S3ListBucketForCloudFront` sid. | string | `{}` | no |
 | aliases | List of FQDN's - Used to set the Alternate Domain Names (CNAMEs) setting on Cloudfront | list(string) | `<list>` | no |
 | allowed_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) for AWS CloudFront | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
@@ -308,13 +309,13 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [Jamie-BitFlight_homepage]: https://github.com/Jamie-BitFlight
-  [Jamie-BitFlight_avatar]: https://github.com/Jamie-BitFlight.png?size=150
+  [Jamie-BitFlight_avatar]: https://img.cloudposse.com/150x150/https://github.com/Jamie-BitFlight.png
   [cliveza_homepage]: https://github.com/cliveza
-  [cliveza_avatar]: https://github.com/cliveza.png?size=150
+  [cliveza_avatar]: https://img.cloudposse.com/150x150/https://github.com/cliveza.png
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,6 +3,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acm_certificate_arn | Existing ACM Certificate ARN | string | `` | no |
+| additional_bucket_policy | Additional policies for the bucket. If included in the policies, the variables `$${bucket_name}`, `$${origin_path}` and `$${cloudfront_origin_access_identity_iam_arn}` will be substituted. It is also possible to override the default policy statements by providing statements with `S3GetObjectForCloudFront` and `S3ListBucketForCloudFront` sid. | string | `{}` | no |
 | aliases | List of FQDN's - Used to set the Alternate Domain Names (CNAMEs) setting on Cloudfront | list(string) | `<list>` | no |
 | allowed_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) for AWS CloudFront | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,12 @@ variable "use_regional_s3_endpoint" {
   default     = false
 }
 
+variable "additional_bucket_policy" {
+  type        = string
+  default     = "{}"
+  description = "Additional policies for the bucket. If included in the policies, the variables `$${bucket_name}`, `$${origin_path}` and `$${cloudfront_origin_access_identity_iam_arn}` will be substituted. It is also possible to override the default policy statements by providing statements with `S3GetObjectForCloudFront` and `S3ListBucketForCloudFront` sid."
+}
+
 variable "origin_bucket" {
   type        = string
   default     = ""
@@ -283,34 +289,34 @@ variable "custom_error_response" {
   # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#custom-error-response-arguments
   type = list(object({
     error_caching_min_ttl = string
-    error_code = string
-    response_code = string
-    response_page_path = string
+    error_code            = string
+    response_code         = string
+    response_page_path    = string
   }))
 
   description = "List of one or more custom error response element maps"
-  default = []
+  default     = []
 }
 
 variable "lambda_function_association" {
   type = list(object({
-    event_type = string
+    event_type   = string
     include_body = bool
-    lambda_arn = string
+    lambda_arn   = string
   }))
 
   description = "A config block that triggers a lambda function with specific actions"
-  default = []
+  default     = []
 }
 
 variable "web_acl_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "ID of the AWS WAF web ACL that is associated with the distribution"
 }
 
 variable "wait_for_deployment" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed"
 }


### PR DESCRIPTION
* additional bucket policy

* fixed readme. added ability to override default bucket policy

* also make it possible to include aws_cloudfront_origin_access_identity.default.iam_arn in the policy override